### PR TITLE
US18 - Add /ready endpoint and ignore .pytest_cache

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .env
 .git
 .gitignore
+.pytest_cache
 .venv
 .private
 .claude

--- a/app/main.py
+++ b/app/main.py
@@ -28,3 +28,30 @@ app = FastAPI(title="RAG Knowledge Assistant", lifespan=lifespan)
 async def health() -> dict[str, str]:
     return {"status": "ok"}
 
+
+@app.get("/ready")
+async def ready() -> JSONResponse:
+    db_status = "down"
+    if _engine is not None:
+        try:
+            async with _engine.connect() as conn:
+                await conn.execute(text("SELECT 1"))
+            db_status = "up"
+        except Exception:
+            pass
+
+    ollama_status = "n/a"
+    if settings.LLM_PROVIDER == "ollama":
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.get(f"{settings.OLLAMA_HOST}/api/tags", timeout=3.0)
+            ollama_status = "up" if resp.status_code == 200 else "down"
+        except Exception:
+            ollama_status = "down"
+
+    overall = "ok" if db_status == "up" else "degraded"
+    code = 200 if db_status == "up" else 503
+    return JSONResponse(
+        content={"status": overall, "db": db_status, "ollama": ollama_status},
+        status_code=code,
+    )


### PR DESCRIPTION
## Summary of changes:
- Introduce a /ready readiness endpoint that verifies DB connectivity and, when using Ollama as LLM provider, checks the Ollama /api/tags endpoint.
- The endpoint returns JSON with overall, db, and ollama statuses and uses HTTP 200 when DB is up or 503 when degraded.
- Also add .pytest_cache to .dockerignore to avoid committing test cache artifacts.

## Screenshots:
### /ready endpoint with db running:
<img width="618" height="254" alt="image" src="https://github.com/user-attachments/assets/e3532868-517b-4c2f-9400-504b678dc483" />

### /ready endpoint with db turned off:
<img width="1141" height="447" alt="image" src="https://github.com/user-attachments/assets/7b2b85c8-6c15-4580-8c91-f873b2c89262" />
