### PR TITLE
US21 - Added database models

### DIFF
--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,7 @@
+from app.models.base import Base
+from app.models.chunk import Chunk
+from app.models.document import Document
+from app.models.query_history import QueryHistory
+from app.models.user import User
+
+__all__ = ["Base", "User", "Document", "Chunk", "QueryHistory"]

--- a/app/models/base.py
+++ b/app/models/base.py
@@ -1,0 +1,5 @@
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    pass

--- a/app/models/chunk.py
+++ b/app/models/chunk.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from pgvector.sqlalchemy import Vector
+from sqlalchemy import DateTime, ForeignKey, Integer, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+if TYPE_CHECKING:
+    from app.models.document import Document
+    from app.models.user import User
+
+
+class Chunk(Base):
+    __tablename__ = "chunks"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    document_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("documents.id", ondelete="CASCADE"), index=True
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    chunk_index: Mapped[int] = mapped_column(Integer)
+    content: Mapped[str] = mapped_column(Text)
+    embedding: Mapped[list[float]] = mapped_column(Vector(768))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    document: Mapped[Document] = relationship(back_populates="chunks")
+    user: Mapped[User] = relationship(back_populates="chunks")

--- a/app/models/document.py
+++ b/app/models/document.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, ForeignKey, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+if TYPE_CHECKING:
+    from app.models.chunk import Chunk
+    from app.models.user import User
+
+
+class Document(Base):
+    __tablename__ = "documents"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    filename: Mapped[str] = mapped_column(String(255))
+    # "processing" | "ready" | "failed"
+    status: Mapped[str] = mapped_column(String(20), default="processing")
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    user: Mapped[User] = relationship(back_populates="documents")
+    chunks: Mapped[list[Chunk]] = relationship(
+        back_populates="document", cascade="all, delete-orphan"
+    )

--- a/app/models/query_history.py
+++ b/app/models/query_history.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Text, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+if TYPE_CHECKING:
+    from app.models.user import User
+
+
+class QueryHistory(Base):
+    __tablename__ = "query_history"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), index=True
+    )
+    question: Mapped[str] = mapped_column(Text)
+    answer: Mapped[str] = mapped_column(Text)
+    used_web_search: Mapped[bool] = mapped_column(Boolean, default=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    user: Mapped[User] = relationship(back_populates="query_history")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import DateTime, String, func
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base
+
+if TYPE_CHECKING:
+    from app.models.chunk import Chunk
+    from app.models.document import Document
+    from app.models.query_history import QueryHistory
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    email: Mapped[str] = mapped_column(String(255), unique=True, index=True)
+    hashed_password: Mapped[str] = mapped_column(String(255))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), server_default=func.now())
+
+    documents: Mapped[list[Document]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )
+    chunks: Mapped[list[Chunk]] = relationship(back_populates="user", cascade="all, delete-orphan")
+    query_history: Mapped[list[QueryHistory]] = relationship(
+        back_populates="user", cascade="all, delete-orphan"
+    )


### PR DESCRIPTION
## Summary

Add database models for #21 

## Changes

- Add SQLAlchemy 2.0 ORM models.
- Models: User, Document, Chunk, QueryHistory.
- All foreign keys cascade on delete.
- Exposed via app/models/__init__.py so a single import registers all models.

-

## Test plan

- [X] `make lint` passes
- [X] `make typecheck` passes
- [X] `make test` passes
- [ ] Manually test the newly added flow - Not able to test with current changes
- [ ] Edge cases covered - Not able to test with current changes

## Notes for reviewer

None
