### PR TITLE
US23 - Add initial DB migration and update contributing doc

### DIFF
--- a/app/db/migrations/versions/20260530_91767c7c47f0_init_migration.py
+++ b/app/db/migrations/versions/20260530_91767c7c47f0_init_migration.py
@@ -1,0 +1,91 @@
+"""init_migration
+
+Revision ID: 91767c7c47f0
+Revises: 
+Create Date: 2026-05-30 20:18:55.172654
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from pgvector.sqlalchemy import Vector
+
+
+revision: str = '91767c7c47f0'
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+
+    # Create users table
+    op.create_table('users',
+    sa.Column('id', sa.Uuid(), nullable=False),
+    sa.Column('email', sa.String(length=255), nullable=False),
+    sa.Column('hashed_password', sa.String(length=255), nullable=False),
+    sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_users_email'), 'users', ['email'], unique=True)
+
+    # Create documents table
+    op.create_table('documents',
+    sa.Column('id', sa.Uuid(), nullable=False),
+    sa.Column('user_id', sa.Uuid(), nullable=False),
+    sa.Column('filename', sa.String(length=255), nullable=False),
+    sa.Column('status', sa.String(length=20), nullable=False),
+    sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_documents_user_id'), 'documents', ['user_id'], unique=False)
+
+    # Create query_history table
+    op.create_table('query_history',
+    sa.Column('id', sa.Uuid(), nullable=False),
+    sa.Column('user_id', sa.Uuid(), nullable=False),
+    sa.Column('question', sa.Text(), nullable=False),
+    sa.Column('answer', sa.Text(), nullable=False),
+    sa.Column('used_web_search', sa.Boolean(), nullable=False),
+    sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_query_history_user_id'), 'query_history', ['user_id'], unique=False)
+
+    # Create chunks table
+    op.create_table('chunks',
+    sa.Column('id', sa.Uuid(), nullable=False),
+    sa.Column('document_id', sa.Uuid(), nullable=False),
+    sa.Column('user_id', sa.Uuid(), nullable=False),
+    sa.Column('chunk_index', sa.Integer(), nullable=False),
+    sa.Column('content', sa.Text(), nullable=False),
+    sa.Column('embedding', Vector(768), nullable=False),
+    sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+    sa.ForeignKeyConstraint(['document_id'], ['documents.id'], ondelete='CASCADE'),
+    sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+    sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_chunks_document_id'), 'chunks', ['document_id'], unique=False)
+    op.create_index(op.f('ix_chunks_user_id'), 'chunks', ['user_id'], unique=False)
+    op.execute(
+        "CREATE INDEX ix_chunks_embedding ON chunks "
+        "USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100)"
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_chunks_user_id'), table_name='chunks')
+    op.drop_index(op.f('ix_chunks_document_id'), table_name='chunks')
+    op.drop_index("ix_chunks_embedding", table_name="chunks")
+    op.drop_table('chunks')
+    op.drop_index(op.f('ix_query_history_user_id'), table_name='query_history')
+    op.drop_table('query_history')
+    op.drop_index(op.f('ix_documents_user_id'), table_name='documents')
+    op.drop_table('documents')
+    op.drop_index(op.f('ix_users_email'), table_name='users')
+    op.drop_table('users')

--- a/app/db/migrations/versions/20260530_91767c7c47f0_init_migration.py
+++ b/app/db/migrations/versions/20260530_91767c7c47f0_init_migration.py
@@ -5,17 +5,16 @@ Revises:
 Create Date: 2026-05-30 20:18:55.172654
 
 """
-from typing import Sequence, Union
+from collections.abc import Sequence
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 from pgvector.sqlalchemy import Vector
 
-
 revision: str = '91767c7c47f0'
-down_revision: Union[str, None] = None
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -43,6 +43,40 @@ make lint && make fmt && make test
 
 ---
 
+## Database migrations
+
+### Applying migrations
+
+```bash
+make migrate
+```
+
+Run this after cloning, after pulling a branch that added a migration, and in CI before tests.
+
+### Creating a migration
+
+Only needed when you change a model (add/remove a table or column). Run inside the app container so it can compare your models against the live database:
+
+```bash
+docker compose exec app alembic revision --autogenerate -m "short description of change"
+```
+
+This generates a file in `app/db/migrations/versions/`. **Always review it before applying**.
+
+```bash
+docker compose build migrate
+make migrate
+```
+
+### Rolling back
+
+```bash
+docker compose exec app alembic downgrade base    # undo all migrations
+docker compose exec app alembic downgrade -1      # undo only the most recent
+```
+
+---
+
 ## Branch naming
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,9 @@ line-length = 100
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP"]
 
+[tool.ruff.lint.per-file-ignores]
+"app/db/migrations/versions/*.py" = ["E501"]
+
 [tool.mypy]
 python_version = "3.11"
 strict = true


### PR DESCRIPTION
## Summary

Add the initial migration and document the commands in CONTRIBUTING.md. Related to #23.

## Changes

- Add an initial migration that creates users, documents, query_history, and chunks tables.
- The migration enables the pgvector extension, defines a Vector(768) embedding column on chunks, and creates an ivfflat index for vector similarity; it also sets up created_at defaults, unique/index constraints, and cascading foreign keys. 
- Update CONTRIBUTING.md with a Database migrations section describing how to apply, create, and roll back migrations.
- Update pyproject.toml to ignore `E501 Line too long` errors in migrations


## Test plan

- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes
- [x] Manually test the newly added flow
- [ ] Edge cases covered - No edge cases 