### PR TITLE
US24 - Add async DB session and integrate engine

### DIFF
--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,0 +1,18 @@
+from collections.abc import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.config import settings
+
+engine = create_async_engine(settings.DATABASE_URL)
+
+AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def get_db() -> AsyncGenerator[AsyncSession, None]:
+    async with AsyncSessionLocal() as session:
+        try:
+            yield session
+        except Exception:
+            await session.rollback()
+            raise

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
@@ -5,20 +6,17 @@ import httpx
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from sqlalchemy import text
-from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from app.config import settings
+from app.db.session import engine
 
-_engine: AsyncEngine | None = None
+logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-    global _engine
-    _engine = create_async_engine(settings.DATABASE_URL)
     yield
-    if _engine:
-        await _engine.dispose()
+    await engine.dispose()
 
 
 app = FastAPI(title="RAG Knowledge Assistant", lifespan=lifespan)
@@ -32,13 +30,12 @@ async def health() -> dict[str, str]:
 @app.get("/ready")
 async def ready() -> JSONResponse:
     db_status = "down"
-    if _engine is not None:
-        try:
-            async with _engine.connect() as conn:
-                await conn.execute(text("SELECT 1"))
-            db_status = "up"
-        except Exception:
-            pass
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+        db_status = "up"
+    except Exception as exc:
+        logger.warning("DB readiness check failed: %s", exc)
 
     ollama_status = "n/a"
     if settings.LLM_PROVIDER == "ollama":
@@ -46,7 +43,8 @@ async def ready() -> JSONResponse:
             async with httpx.AsyncClient() as client:
                 resp = await client.get(f"{settings.OLLAMA_HOST}/api/tags", timeout=3.0)
             ollama_status = "up" if resp.status_code == 200 else "down"
-        except Exception:
+        except Exception as exc:
+            logger.warning("Ollama readiness check failed: %s", exc)
             ollama_status = "down"
 
     overall = "ok" if db_status == "up" else "degraded"


### PR DESCRIPTION
## Summary

Add async DB session factory and update `/ready` DB check logging. Related to #24.

## Changes

- Add app/db/session.py to centralize the async SQLAlchemy engine and sessionmaker  and provide get_db() async dependency with rollback on error.
- Update app/main.py to import and reuse the shared engine: dispose it in the lifespan, use it for the /ready DB check, and add logging for DB and Ollama readiness failures.

## Test plan

- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes
- [x] Manually test the newly added flow
- No new edge cases introduced

### Ready endpoint showing db is up:
<img width="314" height="199" alt="image" src="https://github.com/user-attachments/assets/c1a48246-ca3d-4120-8a28-976aa97f8593" />

## Notes for reviewer

I have choosen to not use get_db in the `/ready` endpoint function, this was done intentionlly to test the engine directly and not in a session
