### PR TITLE
chore - Add make stop/start targets and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,15 @@
-.PHONY: up down migrate pull-models test lint fmt typecheck shell
+.PHONY: up down stop start migrate pull-models test lint fmt typecheck shell
 
 override ARGS += $(FLAGS)
 
 up:
 	docker compose up -d --build $(ARGS)
+
+stop:
+	docker compose stop $(ARGS)
+
+start:
+	docker compose start $(ARGS)
 
 down:
 	docker compose down $(ARGS)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -27,7 +27,9 @@ The app reloads automatically on file changes (uvicorn `--reload` + volume mount
 | Command | What it does |
 |---|---|
 | `make up` | Build images and start all services |
-| `make down` | Stop and remove containers |
+| `make stop` | Pause all containers (preserves state, fast to resume) |
+| `make start` | Resume paused containers |
+| `make down` | Stop and remove containers (full teardown) |
 | `make migrate` | Run pending Alembic migrations |
 | `make test` | Run the full pytest suite inside the app container |
 | `make lint` | Run ruff check (linting) |


### PR DESCRIPTION
- Add `stop` and `start` Makefile targets and update the .PHONY list.
- Update CONTRIBUTING.md to document the new `make stop` and `make start` commands and clarify the difference between `make stop` and `make down`.

## Summary

<!-- What does this PR do and why? Link the issue to PR and/or branch it fixes. -->

## Changes

<!-- Bullet list of the main changes. -->

-

## Test plan

<!-- How to you verify your changes work? -->

- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes
- [x] Manually test the newly added flow
- [ ] Edge cases covered

## Notes for reviewer

None
