### PR TITLE
US3.4 - Add /auth/me endpoint and get_current_user

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,5 @@ __pycache__
 .private
 .claude
 docs
+.postman
+postman

--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,7 @@ infra/terraform/.terraform/
 .claude/
 CLAUDE.md
 RAG-Knowledge-Assistant.code-workspace
+
+# Postman
+.postman/
+postman/

--- a/app/dependencies.py
+++ b/app/dependencies.py
@@ -1,0 +1,47 @@
+import uuid
+from typing import Annotated
+
+import jwt
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.models.user import User
+from app.services.auth_service import decode_token
+
+_bearer = HTTPBearer(auto_error=False)
+
+
+async def get_current_user(
+    credentials: Annotated[HTTPAuthorizationCredentials | None, Depends(_bearer)],
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    if credentials is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+
+    try:
+        payload = decode_token(credentials.credentials)
+    except jwt.PyJWTError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid or expired token"
+        )
+
+    if payload.get("type") != "access":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token type")
+
+    raw_id: str | None = payload.get("sub")
+    if raw_id is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token claims")
+
+    try:
+        user_id = uuid.UUID(raw_id)
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token claims")
+
+    user = await db.get(User, user_id)
+
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+
+    return user

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -7,8 +7,15 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_db
+from app.dependencies import get_current_user
 from app.models.user import User
-from app.schemas.auth import LoginRequest, RefreshRequest, RegisterRequest, TokenResponse
+from app.schemas.auth import (
+    LoginRequest,
+    RefreshRequest,
+    RegisterRequest,
+    TokenResponse,
+    UserResponse,
+)
 from app.services.auth_service import (
     create_access_token,
     create_refresh_token,
@@ -73,6 +80,11 @@ async def refresh(request: RefreshRequest) -> TokenResponse:
         access_token=create_access_token(user_id),
         refresh_token=create_refresh_token(user_id),
     )
+
+
+@router.get("/me", response_model=UserResponse)
+async def me(current_user: User = Depends(get_current_user)) -> User:
+    return current_user
 
 
 @router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)

--- a/app/schemas/auth.py
+++ b/app/schemas/auth.py
@@ -1,4 +1,7 @@
-from pydantic import BaseModel, EmailStr
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, EmailStr
 
 
 class RegisterRequest(BaseModel):
@@ -19,3 +22,11 @@ class TokenResponse(BaseModel):
 
 class RefreshRequest(BaseModel):
     refresh_token: str
+
+
+class UserResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    email: str
+    created_at: datetime

--- a/tests/integration/test_auth_routes.py
+++ b/tests/integration/test_auth_routes.py
@@ -1,7 +1,7 @@
+import asyncio
 import uuid
 
 from httpx import AsyncClient
-from time import sleep
 
 
 def unique_email() -> str:
@@ -70,7 +70,7 @@ async def test_login_unknown_email_returns_401(client: AsyncClient) -> None:
 async def test_login_and_register_return_different_tokens(client: AsyncClient) -> None:
     email = unique_email()
     reg = await client.post("/auth/register", json={"email": email, "password": "password123"})
-    sleep(5)
+    await asyncio.sleep(1)
     login = await client.post("/auth/login", json={"email": email, "password": "password123"})
     assert reg.json()["access_token"] != login.json()["access_token"]
 
@@ -112,7 +112,7 @@ async def test_refresh_returns_different_tokens_than_original(client: AsyncClien
     )
     original_access = reg.json()["access_token"]
     refresh_token = reg.json()["refresh_token"]
-    sleep(5)
+    await asyncio.sleep(1)
     refreshed = await client.post("/auth/refresh", json={"refresh_token": refresh_token})
     assert refreshed.json()["access_token"] != original_access
     assert refreshed.json()["refresh_token"] != refresh_token
@@ -126,3 +126,50 @@ async def test_refresh_returns_different_tokens_than_original(client: AsyncClien
 async def test_logout_returns_204(client: AsyncClient) -> None:
     response = await client.post("/auth/logout")
     assert response.status_code == 204
+
+
+# ---------------------------------------------------------------------------
+# GET /auth/me
+# ---------------------------------------------------------------------------
+
+
+async def test_me_returns_user_info(client: AsyncClient) -> None:
+    email = unique_email()
+    reg = await client.post("/auth/register", json={"email": email, "password": "password123"})
+    access_token = reg.json()["access_token"]
+    response = await client.get("/auth/me", headers={"Authorization": f"Bearer {access_token}"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["email"] == email
+    assert "id" in body
+    assert "created_at" in body
+    assert "hashed_password" not in body
+
+
+async def test_me_no_token_returns_401(client: AsyncClient) -> None:
+    response = await client.get("/auth/me")
+    assert response.status_code == 401
+
+
+async def test_me_refresh_token_returns_401(client: AsyncClient) -> None:
+    reg = await client.post(
+        "/auth/register", json={"email": unique_email(), "password": "password123"}
+    )
+    refresh_token = reg.json()["refresh_token"]
+    response = await client.get("/auth/me", headers={"Authorization": f"Bearer {refresh_token}"})
+    assert response.status_code == 401
+
+
+async def test_me_tampered_token_returns_401(client: AsyncClient) -> None:
+    reg = await client.post(
+        "/auth/register", json={"email": unique_email(), "password": "password123"}
+    )
+    token = reg.json()["access_token"]
+    tampered = token[:-4] + "xxxx"
+    response = await client.get("/auth/me", headers={"Authorization": f"Bearer {tampered}"})
+    assert response.status_code == 401
+
+
+async def test_me_garbage_token_returns_401(client: AsyncClient) -> None:
+    response = await client.get("/auth/me", headers={"Authorization": "Bearer not.a.real.token"})
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary

Add get_current_user and integration tests

## Changes

- Introduce a get_current_user dependency that validates Bearer tokens, ensures token type is access, decodes subject UUID and loads the User from the DB.
- Add /auth/me route to app/routers/auth.py returning a sanitized UserResponse.
- Add UserResponse schema (id, email, created_at) to app/schemas/auth.py with from_attributes config.
- Update integration tests to use asyncio.sleep and add comprehensive tests for /auth/me (success, missing token, refresh token, tampered token, garbage token).
- Also add Postman collection/resource and workspace files to .gitignore and .dockerignore

## Test plan

- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes
- [x] Manually test the newly added flow
- [ ] Edge cases covered (List in PR description)

## Notes for reviewer

Added postman related folders to .ignore... files