### PR TITLE
US4.3 - Add embeddings service and startup validation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -10,12 +10,14 @@ from sqlalchemy import text
 from app.config import settings
 from app.db.session import engine
 from app.routers.auth import router as auth_router
+from app.services.embeddings import get_embeddings, validate_embedding_dim
 
 logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    validate_embedding_dim(get_embeddings())
     yield
     await engine.dispose()
 

--- a/app/services/embeddings.py
+++ b/app/services/embeddings.py
@@ -1,0 +1,22 @@
+from langchain_core.embeddings import Embeddings
+from langchain_ollama import OllamaEmbeddings
+from langchain_openai import OpenAIEmbeddings
+from pydantic import SecretStr
+
+from app.config import settings
+
+
+def get_embeddings() -> Embeddings:
+    if settings.LLM_PROVIDER == "openai":
+        return OpenAIEmbeddings(
+            api_key=SecretStr(settings.OPENAI_API_KEY),
+            model="text-embedding-3-small",
+            dimensions=settings.EMBED_DIM,
+        )
+    return OllamaEmbeddings(base_url=settings.OLLAMA_HOST, model=settings.OLLAMA_EMBED_MODEL)
+
+
+def validate_embedding_dim(model: Embeddings) -> None:
+    dim = len(model.embed_query("test"))
+    expected = settings.EMBED_DIM
+    assert dim == expected, f"Embedding dim mismatch: expected {expected}, got {dim}"

--- a/tests/unit/test_embeddings.py
+++ b/tests/unit/test_embeddings.py
@@ -1,0 +1,56 @@
+import pytest
+from langchain_ollama import OllamaEmbeddings
+from langchain_openai import OpenAIEmbeddings
+
+from app.config import settings
+from app.services.embeddings import get_embeddings, validate_embedding_dim
+
+# ---------------------------------------------------------------------------
+# Provider selection
+# ---------------------------------------------------------------------------
+
+
+def test_ollama_provider_returns_ollama_embeddings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "LLM_PROVIDER", "ollama")
+    assert isinstance(get_embeddings(), OllamaEmbeddings)
+
+
+def test_ollama_provider_uses_configured_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "LLM_PROVIDER", "ollama")
+    model = get_embeddings()
+    assert model.model == settings.OLLAMA_EMBED_MODEL
+
+
+def test_openai_provider_returns_openai_embeddings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "LLM_PROVIDER", "openai")
+    monkeypatch.setattr(settings, "OPENAI_API_KEY", "sk-test")
+    assert isinstance(get_embeddings(), OpenAIEmbeddings)
+
+
+def test_openai_provider_passes_configured_dimensions(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings, "LLM_PROVIDER", "openai")
+    monkeypatch.setattr(settings, "OPENAI_API_KEY", "sk-test")
+    model = get_embeddings()
+    assert model.dimensions == settings.EMBED_DIM
+
+
+# ---------------------------------------------------------------------------
+# Dimension validation
+# ---------------------------------------------------------------------------
+
+
+class _FakeModel:
+    def __init__(self, dim: int) -> None:
+        self._dim = dim
+
+    def embed_query(self, text: str) -> list[float]:
+        return [0.0] * self._dim
+
+
+def test_validate_embedding_dim_passes_for_correct_dimension() -> None:
+    validate_embedding_dim(_FakeModel(settings.EMBED_DIM))
+
+
+def test_validate_embedding_dim_raises_for_wrong_dimension() -> None:
+    with pytest.raises(AssertionError):
+        validate_embedding_dim(_FakeModel(settings.EMBED_DIM + 1))


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? Link the issue to PR and/or branch it fixes. -->
Add embedding provider and unit tests. Related to #31 

## Changes

<!-- Bullet list of the main changes. -->

- Introduce app.services.embeddings with get_embeddings and validate_embedding_dim to assert the returned embedding vector length matches settings.EMBED_DIM.
- Call validate_embedding_dim(get_embeddings()) during FastAPI lifespan in app.main so mismatches are caught at startup.
- Add unit tests covering provider selection, configuration propagation, and dimension validation.

## Test plan

<!-- How to you verify your changes work? -->

- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes
- [ ] Manually test the newly added flow
- [ ] Edge cases covered

## Notes for reviewer

<!-- Anything the reviewer should know or anything that should be known for later tracking purposes: trade-offs, follow-up issues, known limitations. -->
None
