### PR TITLE
US4.5 - Add document upload endpoint and tests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -10,6 +10,7 @@ from sqlalchemy import text
 from app.config import settings
 from app.db.session import engine
 from app.routers.auth import router as auth_router
+from app.routers.documents import router as documents_router
 from app.services.embeddings import get_embeddings, validate_embedding_dim
 
 logger = logging.getLogger(__name__)
@@ -24,6 +25,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
 app = FastAPI(title="RAG Knowledge Assistant", lifespan=lifespan)
 app.include_router(auth_router)
+app.include_router(documents_router)
 
 
 @app.get("/health")

--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -1,0 +1,112 @@
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.dependencies import get_current_user
+from app.models.chunk import Chunk
+from app.models.document import Document
+from app.models.user import User
+from app.schemas.documents import DocumentResponse
+from app.services.chunker import chunk
+from app.services.embeddings import get_embeddings
+from app.services.parsers import SUPPORTED_TYPES, UnsupportedFileTypeError, parse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/documents", tags=["documents"])
+
+_MAX_BYTES = 50 * 1024 * 1024  # 50 MB
+
+_MAGIC_BYTES: dict[str, bytes] = {
+    "pdf": b"%PDF",
+    "docx": b"PK\x03\x04",
+}
+
+
+def _magic_ok(content: bytes, ext: str) -> bool:
+    expected = _MAGIC_BYTES.get(ext)
+    if expected is None:
+        return True
+    return content[: len(expected)] == expected
+
+
+@router.post("/upload", response_model=DocumentResponse, status_code=status.HTTP_201_CREATED)
+async def upload_document(
+    file: UploadFile,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> Document:
+    filename = file.filename or ""
+    ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+
+    if ext not in SUPPORTED_TYPES:
+        supported = ", ".join(sorted(SUPPORTED_TYPES))
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail=f"Unsupported file type '.{ext}'. Supported: {supported}",
+        )
+
+    content = await file.read()
+
+    if len(content) > _MAX_BYTES:
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail="File exceeds the 50 MB limit.",
+        )
+
+    if not _magic_ok(content, ext):
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail="File content does not match the declared extension.",
+        )
+
+    document = Document(user_id=current_user.id, filename=filename, status="processing")
+    db.add(document)
+    await db.commit()
+    await db.refresh(document)
+
+    try:
+        text = parse(content, ext)
+        chunk_texts = chunk(text)
+        if chunk_texts:
+            model = get_embeddings()
+            vectors = model.embed_documents(chunk_texts)
+            db.add_all(
+                [
+                    Chunk(
+                        document_id=document.id,
+                        user_id=current_user.id,
+                        chunk_index=i,
+                        content=chunk_texts[i],
+                        embedding=vectors[i],
+                    )
+                    for i in range(len(chunk_texts))
+                ]
+            )
+        document.status = "ready"
+        await db.commit()
+        await db.refresh(document)
+        return document
+    except UnsupportedFileTypeError:
+        await db.rollback()
+        doc = await db.get(Document, document.id)
+        if doc is not None:
+            doc.status = "failed"
+            await db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+            detail="File type is not supported.",
+        )
+    except Exception:
+        logger.exception("Failed to process document %s", document.id)
+        await db.rollback()
+        doc = await db.get(Document, document.id)
+        if doc is not None:
+            doc.status = "failed"
+            await db.commit()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Document processing failed.",
+        )

--- a/app/schemas/documents.py
+++ b/app/schemas/documents.py
@@ -1,0 +1,13 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class DocumentResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    filename: str
+    status: str
+    created_at: datetime

--- a/app/services/parsers.py
+++ b/app/services/parsers.py
@@ -6,6 +6,10 @@ from pypdf import PdfReader
 SUPPORTED_TYPES = frozenset({"pdf", "docx", "txt", "md"})
 
 
+class UnsupportedFileTypeError(ValueError):
+    pass
+
+
 def parse(file_bytes: bytes, file_type: str) -> str:
     match file_type.lower():
         case "pdf":
@@ -15,7 +19,7 @@ def parse(file_bytes: bytes, file_type: str) -> str:
         case "txt" | "md":
             return file_bytes.decode("utf-8")
         case _:
-            raise ValueError(
+            raise UnsupportedFileTypeError(
                 f"Unsupported file type: {file_type!r}. "
                 + f"Supported: {', '.join(sorted(SUPPORTED_TYPES))}"
             )

--- a/tests/integration/test_documents.py
+++ b/tests/integration/test_documents.py
@@ -1,0 +1,139 @@
+import io
+import uuid
+
+from fpdf import FPDF
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.chunk import Chunk
+
+
+def unique_email() -> str:
+    return f"docs_{uuid.uuid4().hex[:8]}@example.com"
+
+
+def _make_pdf() -> bytes:
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Helvetica", size=12)
+    pdf.cell(text="This is a test document for the upload integration test.")
+    buf = io.BytesIO()
+    pdf.output(buf)
+    return buf.getvalue()
+
+
+async def _register_and_token(client: AsyncClient) -> tuple[str, uuid.UUID]:
+    reg = await client.post(
+        "/auth/register", json={"email": unique_email(), "password": "pass1234"}
+    )
+    token = reg.json()["access_token"]
+    me = await client.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+    user_id = uuid.UUID(me.json()["id"])
+    return token, user_id
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+
+
+async def test_upload_pdf_returns_201_with_ready_status(client: AsyncClient) -> None:
+    token, _ = await _register_and_token(client)
+
+    response = await client.post(
+        "/documents/upload",
+        files={"file": ("notes.pdf", _make_pdf(), "application/pdf")},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["status"] == "ready"
+    assert body["filename"] == "notes.pdf"
+    assert "id" in body
+    assert "created_at" in body
+
+
+async def test_upload_pdf_persists_chunks_with_correct_user_id(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token, user_id = await _register_and_token(client)
+
+    response = await client.post(
+        "/documents/upload",
+        files={"file": ("notes.pdf", _make_pdf(), "application/pdf")},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 201
+    doc_id = uuid.UUID(response.json()["id"])
+
+    result = await db_session.execute(select(Chunk).where(Chunk.document_id == doc_id))
+    chunks = result.scalars().all()
+
+    assert len(chunks) > 0
+    assert all(c.user_id == user_id for c in chunks)
+
+
+# ---------------------------------------------------------------------------
+# Validation — extension and magic bytes
+# ---------------------------------------------------------------------------
+
+
+async def test_upload_unsupported_extension_returns_415(client: AsyncClient) -> None:
+    token, _ = await _register_and_token(client)
+
+    response = await client.post(
+        "/documents/upload",
+        files={"file": ("malware.exe", b"MZ fake exe", "application/octet-stream")},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 415
+
+
+async def test_upload_wrong_magic_bytes_returns_415(client: AsyncClient) -> None:
+    token, _ = await _register_and_token(client)
+
+    # JPEG bytes disguised as a PDF
+    response = await client.post(
+        "/documents/upload",
+        files={"file": ("sneaky.pdf", b"\xff\xd8\xff fake jpeg", "application/pdf")},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 415
+
+
+# ---------------------------------------------------------------------------
+# Validation — file size
+# ---------------------------------------------------------------------------
+
+
+async def test_upload_oversized_file_returns_413(client: AsyncClient) -> None:
+    token, _ = await _register_and_token(client)
+
+    # Valid PDF magic bytes followed by enough zeros to exceed 50 MB
+    big_content = b"%PDF" + b"\x00" * (50 * 1024 * 1024)
+
+    response = await client.post(
+        "/documents/upload",
+        files={"file": ("huge.pdf", big_content, "application/pdf")},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 413
+
+
+# ---------------------------------------------------------------------------
+# Authentication
+# ---------------------------------------------------------------------------
+
+
+async def test_upload_without_auth_returns_401(client: AsyncClient) -> None:
+    response = await client.post(
+        "/documents/upload",
+        files={"file": ("notes.pdf", b"%PDF fake", "application/pdf")},
+    )
+
+    assert response.status_code == 401

--- a/tests/integration/test_vector_store.py
+++ b/tests/integration/test_vector_store.py
@@ -9,7 +9,7 @@ from app.models.user import User
 from app.services.vector_store import bulk_insert_chunks, similarity_search
 
 
-def unit_vector(index: int, dim: int = settings.EMBEDDING_DIM, sign: float = 1.0) -> list[float]:
+def unit_vector(index: int, dim: int = settings.EMBED_DIM, sign: float = 1.0) -> list[float]:
     vec = [0.0] * dim
     vec[index] = sign
     return vec


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? Link the issue to PR and/or branch it fixes. -->
Add document upload endpoint and related integration tests. Related to #33 

## Changes

<!-- Bullet list of the main changes. -->

- Introduce a /documents/upload endpoint with validation, parsing, chunking and embedding persistence.
- Add app/routers/documents.py implementing file extension & magic-byte checks, size limit, parsing via services.parsers, chunking, embedding generation and storing Chunk records.
- Document status is updated and errors map to proper HTTP responses.
- Register the router in main.py and add a Pydantic DocumentResponse schema.
- Refactor parsers.py to introduce UnsupportedFileTypeError for clearer error handling.
- Add comprehensive integration tests for document uploads and adjust an existing vector-store test to use settings.EMBED_DIM.

## Test plan

<!-- How to you verify your changes work? -->

- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes
- [x] Manually test the newly added flow
- [ ] Edge cases covered

## Notes for reviewer

<!-- Anything the reviewer should know or anything that should be known for later tracking purposes: trade-offs, follow-up issues, known limitations. -->
None

