### PR TITLE
US4.6 - Add document listing and deletion endpoints

### DIFF
--- a/app/routers/documents.py
+++ b/app/routers/documents.py
@@ -1,6 +1,8 @@
 import logging
+import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, UploadFile, status
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_db
@@ -110,3 +112,31 @@ async def upload_document(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Document processing failed.",
         )
+
+
+@router.get("", response_model=list[DocumentResponse])
+async def list_documents(
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> list[Document]:
+    result = await db.execute(
+        select(Document)
+        .where(Document.user_id == current_user.id)
+        .order_by(Document.created_at.desc())
+    )
+    return list(result.scalars().all())
+
+
+@router.delete("/{doc_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_document(
+    doc_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+) -> None:
+    doc = await db.get(Document, doc_id)
+    if doc is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Document not found.")
+    if doc.user_id != current_user.id:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Access denied.")
+    await db.execute(delete(Document).where(Document.id == doc_id))
+    await db.commit()

--- a/tests/integration/test_documents.py
+++ b/tests/integration/test_documents.py
@@ -137,3 +137,137 @@ async def test_upload_without_auth_returns_401(client: AsyncClient) -> None:
     )
 
     assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /documents
+# ---------------------------------------------------------------------------
+
+
+async def test_list_documents_empty_for_new_user(client: AsyncClient) -> None:
+    token, _ = await _register_and_token(client)
+
+    response = await client.get("/documents", headers={"Authorization": f"Bearer {token}"})
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+async def test_list_documents_returns_uploaded_documents(client: AsyncClient) -> None:
+    token, _ = await _register_and_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    await _upload_pdf(client, headers, name="a.pdf")
+    await _upload_pdf(client, headers, name="b.pdf")
+
+    response = await client.get("/documents", headers=headers)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body) == 2
+    assert body[0]["filename"] == "b.pdf"  # most recent first
+    assert body[1]["filename"] == "a.pdf"
+
+
+async def test_list_documents_only_returns_own_documents(client: AsyncClient) -> None:
+    token_a, _ = await _register_and_token(client)
+    token_b, _ = await _register_and_token(client)
+
+    await client.post(
+        "/documents/upload",
+        files={"file": ("secret.pdf", _make_pdf(), "application/pdf")},
+        headers={"Authorization": f"Bearer {token_a}"},
+    )
+
+    response = await client.get("/documents", headers={"Authorization": f"Bearer {token_b}"})
+
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+async def test_list_documents_without_auth_returns_401(client: AsyncClient) -> None:
+    response = await client.get("/documents")
+
+    assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# DELETE /documents/{id}
+# ---------------------------------------------------------------------------
+
+
+async def _upload_pdf(client: AsyncClient, headers: dict[str, str], name: str = "notes.pdf") -> str:
+    upload = await client.post(
+        "/documents/upload",
+        files={"file": (name, _make_pdf(), "application/pdf")},
+        headers=headers,
+    )
+    return upload.json()["id"]
+
+
+async def test_delete_document_returns_204(client: AsyncClient) -> None:
+    token, _ = await _register_and_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    doc_id = await _upload_pdf(client, headers)
+    response = await client.delete(f"/documents/{doc_id}", headers=headers)
+
+    assert response.status_code == 204
+
+
+async def test_delete_document_removes_it_from_list(client: AsyncClient) -> None:
+    token, _ = await _register_and_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    doc_id = await _upload_pdf(client, headers)
+    await client.delete(f"/documents/{doc_id}", headers=headers)
+    response = await client.get("/documents", headers=headers)
+
+    assert response.json() == []
+
+
+async def test_delete_document_cascades_to_chunks(
+    client: AsyncClient, db_session: AsyncSession
+) -> None:
+    token, _ = await _register_and_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    doc_id = uuid.UUID(await _upload_pdf(client, headers))
+
+    await client.delete(f"/documents/{doc_id}", headers=headers)
+
+    result = await db_session.execute(select(Chunk).where(Chunk.document_id == doc_id))
+    assert result.scalars().all() == []
+
+
+async def test_delete_document_wrong_user_returns_403(client: AsyncClient) -> None:
+    token_a, _ = await _register_and_token(client)
+    token_b, _ = await _register_and_token(client)
+
+    upload = await client.post(
+        "/documents/upload",
+        files={"file": ("notes.pdf", _make_pdf(), "application/pdf")},
+        headers={"Authorization": f"Bearer {token_a}"},
+    )
+    doc_id = upload.json()["id"]
+
+    response = await client.delete(
+        f"/documents/{doc_id}", headers={"Authorization": f"Bearer {token_b}"}
+    )
+
+    assert response.status_code == 403
+
+
+async def test_delete_nonexistent_document_returns_404(client: AsyncClient) -> None:
+    token, _ = await _register_and_token(client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    response = await client.delete(f"/documents/{uuid.uuid4()}", headers=headers)
+
+    assert response.status_code == 404
+
+
+async def test_delete_document_without_auth_returns_401(client: AsyncClient) -> None:
+    response = await client.delete(f"/documents/{uuid.uuid4()}")
+
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? Link the issue to PR and/or branch it fixes. -->
Add list document and delete document endpoint and integration tests. Related to #34 

## Changes

<!-- Bullet list of the main changes. -->

- Implement GET /documents to list the current user's documents and DELETE /documents/{id} to remove a document.
- Update imports to use uuid and SQLAlchemy select/delete and commit the deletion.
- Add integration tests for listing, ordering, authorization, deletion behavior, cascading removal of chunks, and unauthenticated access.

## Test plan

<!-- How to you verify your changes work? -->

- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes
- [x] Manually test the newly added flow
- [ ] Edge cases covered

## Notes for reviewer

<!-- Anything the reviewer should know or anything that should be known for later tracking purposes: trade-offs, follow-up issues, known limitations. -->
None
