### PR TITLE
US5.2 - Add retrieve tool for similarity search

### DIFF
--- a/app/services/retrieve_tool.py
+++ b/app/services/retrieve_tool.py
@@ -1,0 +1,17 @@
+import uuid
+
+from langchain_core.tools import BaseTool, tool
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.embeddings import get_embeddings
+from app.services.vector_store import SimilarityResult, similarity_search
+
+
+def make_retrieve_tool(user_id: uuid.UUID, db: AsyncSession) -> BaseTool:
+    @tool
+    async def retrieve(query: str) -> list[SimilarityResult]:
+        """Search the user's documents for passages relevant to the query."""
+        embedding = get_embeddings().embed_query(query)
+        return await similarity_search(db, embedding, user_id)
+
+    return retrieve

--- a/app/services/vector_store.py
+++ b/app/services/vector_store.py
@@ -19,12 +19,7 @@ async def similarity_search(
     db: AsyncSession, query_embedding: list[float], user_id: uuid.UUID, top_k: int = 5
 ) -> list[SimilarityResult]:
     distance = Chunk.embedding.cosine_distance(query_embedding).label("distance")
-    stmt = (
-        select(Chunk, distance)
-        .where(Chunk.user_id == user_id)
-        .order_by(distance)
-        .limit(top_k)
-    )
+    stmt = select(Chunk, distance).where(Chunk.user_id == user_id).order_by(distance).limit(top_k)
     rows = (await db.execute(stmt)).all()
     return [
         SimilarityResult(

--- a/tests/unit/test_retrieve_tool.py
+++ b/tests/unit/test_retrieve_tool.py
@@ -1,0 +1,66 @@
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from app.services.retrieve_tool import make_retrieve_tool
+from app.services.vector_store import SimilarityResult
+
+
+def _make_expected(chunk_id: uuid.UUID, doc_id: uuid.UUID) -> list[SimilarityResult]:
+    return [
+        SimilarityResult(
+            id=chunk_id,
+            content="relevant passage",
+            document_id=doc_id,
+            chunk_index=0,
+            similarity=0.95,
+        )
+    ]
+
+
+async def test_retrieve_tool_calls_similarity_search_with_correct_args() -> None:
+    user_id = uuid.uuid4()
+    expected = _make_expected(uuid.uuid4(), uuid.uuid4())
+    mock_db = MagicMock()
+    fake_embedding = [0.1] * 768
+    mock_search = AsyncMock(return_value=expected)
+
+    with (
+        patch("app.services.retrieve_tool.get_embeddings") as mock_embeddings,
+        patch("app.services.retrieve_tool.similarity_search", mock_search),
+    ):
+        mock_embeddings.return_value.embed_query.return_value = fake_embedding
+        retrieve_tool = make_retrieve_tool(user_id, mock_db)
+        await retrieve_tool.ainvoke({"query": "what is RAG?"})
+
+    mock_search.assert_called_once_with(mock_db, fake_embedding, user_id)
+
+
+async def test_retrieve_tool_returns_similarity_results() -> None:
+    user_id = uuid.uuid4()
+    expected = _make_expected(uuid.uuid4(), uuid.uuid4())
+    mock_db = MagicMock()
+    mock_search = AsyncMock(return_value=expected)
+
+    with (
+        patch("app.services.retrieve_tool.get_embeddings") as mock_embeddings,
+        patch("app.services.retrieve_tool.similarity_search", mock_search),
+    ):
+        mock_embeddings.return_value.embed_query.return_value = [0.0] * 768
+        retrieve_tool = make_retrieve_tool(user_id, mock_db)
+        result = await retrieve_tool.ainvoke({"query": "what is RAG?"})
+
+    assert result == expected
+
+
+def test_retrieve_tool_user_id_not_in_schema() -> None:
+    user_id = uuid.uuid4()
+    mock_db = MagicMock()
+
+    with (
+        patch("app.services.retrieve_tool.get_embeddings"),
+        patch("app.services.retrieve_tool.similarity_search"),
+    ):
+        retrieve_tool = make_retrieve_tool(user_id, mock_db)
+
+    assert "user_id" not in retrieve_tool.args
+    assert "query" in retrieve_tool.args


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? Link the issue to PR and/or branch it fixes. -->
Add make retrieve tool and unit tests. Related to #37 

## Changes

<!-- Bullet list of the main changes. -->

- Introduce make_retrieve_tool which builds a LangChain async tool that embeds a query and performs a similarity_search against a user's vector store, returning a list of SimilarityResult.
- Adds unit tests that mock embeddings and similarity_search to verify the tool calls similarity_search with the correct arguments, returns the expected results, and exposes the correct tool args.


## Test plan

<!-- How to you verify your changes work? -->

- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes
- [ ] Manually test the newly added flow
- [ ] Edge cases covered (List in PR description)

## Notes for reviewer

<!-- Anything the reviewer should know or anything that should be known for later tracking purposes: trade-offs, follow-up issues, known limitations. -->
None
