### PR TITLE
US5.4 - Add clarify_tool and unit tests

### DIFF
--- a/app/services/clarify_tool.py
+++ b/app/services/clarify_tool.py
@@ -1,0 +1,7 @@
+from langchain_core.tools import tool
+
+
+@tool(return_direct=True)
+def clarify_tool(question_to_user: str) -> dict[str, str]:
+    """Ask the user for clarification when the question is ambiguous or incomplete."""
+    return {"type": "clarification", "question": question_to_user}

--- a/tests/unit/test_clarify_tool.py
+++ b/tests/unit/test_clarify_tool.py
@@ -1,0 +1,10 @@
+from app.services.clarify_tool import clarify_tool
+
+
+def test_clarify_tool_returns_expected_shape() -> None:
+    result = clarify_tool.invoke({"question_to_user": "Could you be more specific?"})
+    assert result == {"type": "clarification", "question": "Could you be more specific?"}
+
+
+def test_clarify_tool_return_direct_is_set() -> None:
+    assert clarify_tool.return_direct is True


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? Link the issue to PR and/or branch it fixes. -->
Add clarify tool to prompt the user with a question. Related to #39 

## Changes

<!-- Bullet list of the main changes. -->

- Introduce a new Clarify tool (app/services/clarify_tool.py) decorated with langchain_core.tools.tool(return_direct=True) that returns a clarification payload.
- Add unit tests (tests/unit/test_clarify_tool.py) to verify the tool's returned shape via invoke and that return_direct is True.

## Test plan

<!-- How to you verify your changes work? -->

- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes
- [ ] Manually test the newly added flow
- [ ] Edge cases covered

## Notes for reviewer

<!-- Anything the reviewer should know or anything that should be known for later tracking purposes: trade-offs, follow-up issues, known limitations. -->
None
