### PR TITLE
US5.5 - Add agent builder and unit tests

### DIFF
--- a/app/services/agent.py
+++ b/app/services/agent.py
@@ -1,0 +1,34 @@
+import uuid
+from typing import Any
+
+from langchain.agents import create_agent
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.clarify_tool import clarify_tool
+from app.services.llm import get_chat_model
+from app.services.retrieve_tool import make_retrieve_tool
+from app.services.web_search_tool import web_search_tool
+
+_SYSTEM_PROMPT = (
+    "You are a knowledgeable assistant. "
+    "Always use the retrieve tool to search the user's documents before answering. "
+    "Ground your answers in the retrieved content and cite your sources. "
+    "If the question is unclear or ambiguous, use the clarify tool to ask for more detail. "
+    "Only use the web_search_tool if the answer cannot be found in the user's documents."
+)
+
+_DEFAULT_MAX_ITERATIONS = 10
+
+
+def build_agent(
+    user_id: uuid.UUID,
+    db: AsyncSession,
+    max_iterations: int = _DEFAULT_MAX_ITERATIONS,
+) -> Any:
+    tools = [make_retrieve_tool(user_id, db), web_search_tool, clarify_tool]
+    agent = create_agent(
+        model=get_chat_model(),
+        tools=tools,
+        system_prompt=_SYSTEM_PROMPT,
+    )
+    return agent.with_config({"recursion_limit": max_iterations})

--- a/docs/adr/ADR-004-langgraph-over-langchain.md
+++ b/docs/adr/ADR-004-langgraph-over-langchain.md
@@ -28,19 +28,126 @@ A hand-rolled ReAct loop gives full control but requires re-implementing tool di
 
 ## Decision
 
-Use LangGraph's `create_react_agent`:
+Use LangGraph's prebuilt agent factory (`create_agent` in LangGraph 1.x, formerly `create_react_agent` in earlier versions).
 
 ```python
-from langgraph.prebuilt import create_react_agent
+from langchain.agents import create_agent  # new home in LangGraph 1.x
 
-agent = create_react_agent(
+agent = create_agent(
     model=get_chat_model(),
     tools=[make_retrieve_tool(user_id, db), web_search_tool, clarify_tool],
-    prompt=SYSTEM_PROMPT
+    system_prompt=SYSTEM_PROMPT,
 )
+agent.with_config({"recursion_limit": max_iterations})
 ```
 
-Set `max_iterations` on the agent to prevent infinite loops (default guard is 10 steps).
+Set `recursion_limit` to prevent infinite loops (default guard is 10 steps).
+
+### What the factory builds
+
+`create_agent` is a thin wrapper around a manual `StateGraph`. The graph it constructs is equivalent to writing this by hand:
+
+```python
+from typing import Annotated, Sequence, TypedDict
+
+from langchain_core.messages import BaseMessage
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langgraph.graph import END, StateGraph
+from langgraph.graph.message import add_messages
+from langgraph.prebuilt import ToolNode
+
+class AgentState(TypedDict):
+    messages: Annotated[Sequence[BaseMessage], add_messages]
+
+SYSTEM_PROMPT = """You are a knowledgeable assistant.
+Always use the retrieve tool to search the user's documents before answering.
+Ground your answers in the retrieved content and cite your sources.
+If the question is unclear, use the clarify tool to ask for more detail.
+Only use web_search_tool if the answer cannot be found in the user's documents."""
+
+prompt = ChatPromptTemplate.from_messages([
+    ("system", SYSTEM_PROMPT),
+    MessagesPlaceholder(variable_name="messages"),
+])
+
+tools = [make_retrieve_tool(user_id, db), web_search_tool, clarify_tool]
+llm_with_tools = get_chat_model().bind_tools(tools)
+
+async def call_agent(state: AgentState) -> dict:
+    """
+    The agent node. Calls the LLM with the current conversation history.
+
+    The LLM can respond in two ways:
+      1. A tool call  → execution routes to the tools node next
+      2. A text answer → execution terminates and the answer is returned
+    """
+    formatted = prompt.format_messages(messages=state["messages"])
+    response = await llm_with_tools.ainvoke(formatted)
+    return {"messages": [response]}
+
+tool_node = ToolNode(tools)
+
+def should_continue(state: AgentState) -> str:
+    """
+    Router function — determines what happens after the agent node runs.
+
+    Returns:
+        "tools"  if the LLM chose a tool (tool_calls is non-empty)
+        END      if the LLM produced a final text answer
+    """
+    last_message = state["messages"][-1]
+
+    if hasattr(last_message, "tool_calls") and last_message.tool_calls:
+        return "tools"
+
+    return END
+
+workflow = StateGraph(AgentState)
+
+workflow.add_node("agent", call_agent)
+workflow.add_node("tools", tool_node)
+
+workflow.set_entry_point("agent")
+
+workflow.add_conditional_edges(
+    "agent",
+    should_continue,
+    {
+        "tools": "tools",
+        END: END,
+    },
+)
+
+workflow.add_edge("tools", "agent")
+
+agent = workflow.compile()
+```
+
+### Graph topology
+
+```mermaid
+flowchart TD
+    START([START]) --> agent
+
+    agent["🤖 agent\nLLM decides next action\ncall_agent()"]
+
+    agent --> router{should_continue?}
+
+    router -->|tool_calls present| tools
+    router -->|no tool_calls| DONE([END\nreturn final answer])
+
+    tools["🔧 tools\nToolNode dispatches call\n────────────────────\nretrieve · web_search · clarify"]
+
+    tools -->|loop back| agent
+```
+
+The factory was chosen over the manual form because the graph topology is identical and the factory removes boilerplate that would need to be kept in sync with LangGraph internals as the library evolves. The manual form would be preferred if the project ever needed custom state fields beyond `messages`, additional nodes (e.g. a validation step between tool output and the next LLM call), or different routing logic per tool.
+
+## References
+
+- Manoj Aggarwal — [How to Develop AI Agents Using LangGraph: A Practical Guide](https://www.freecodecamp.org/news/how-to-develop-ai-agents-using-langgraph-a-practical-guide/) (freeCodeCamp, February 2026). The manual `StateGraph` example in this ADR is adapted from this article — specifically the `AgentState(TypedDict)`, `call_agent`, `should_continue`, and graph assembly patterns.
+- [LangGraph official docs](https://python.langchain.com/docs/langgraph)
+- [LangGraph conceptual guide](https://python.langchain.com/docs/concepts/langgraph)
 
 ## Consequences
 

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -1,0 +1,36 @@
+import uuid
+from unittest.mock import MagicMock, patch
+
+from app.services.agent import build_agent
+from app.services.clarify_tool import clarify_tool
+
+
+def _build(max_iterations: int = 10) -> object:
+    with (
+        patch("app.services.agent.get_chat_model") as mock_llm,
+        patch("app.services.agent.make_retrieve_tool", return_value=clarify_tool),
+    ):
+        mock_llm.return_value.bind_tools = MagicMock(return_value=mock_llm.return_value)
+        return build_agent(uuid.uuid4(), MagicMock(), max_iterations=max_iterations)
+
+
+def test_build_agent_returns_compiled_graph() -> None:
+    agent = _build()
+    assert agent is not None
+
+
+def test_build_agent_graph_has_tools_node() -> None:
+    agent = _build()
+    assert "tools" in agent.nodes  # type: ignore[union-attr]
+
+
+def test_build_agent_includes_web_search_and_clarify_tools() -> None:
+    agent = _build()
+    tool_names = set(agent.nodes["tools"].bound.tools_by_name.keys())  # type: ignore[union-attr]
+    assert "web_search_tool" in tool_names
+    assert "clarify_tool" in tool_names
+
+
+def test_build_agent_respects_max_iterations() -> None:
+    agent = _build(max_iterations=5)
+    assert agent.config.get("recursion_limit") == 5  # type: ignore[union-attr]


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? Link the issue to PR and/or branch it fixes. -->
Add LangGrapgh agent and update ADR. Related to #40 

## Changes

<!-- Bullet list of the main changes. -->

- Introduce build_agent in app/services/agent.py to assemble a LangChain agent preconfigured with a system prompt, retrieve/web_search/clarify tools, and a configurable recursion_limit (default 10).
- The function accepts a user_id and AsyncSession and returns the agent bound to the chat model.
- Add unit tests in tests/unit/test_agent.py which patch dependencies to validate the agent is constructed, contains a tools node, includes web_search_tool and clarify_tool, and respects the max_iterations configuration.
- Update ADR to recommend LangGraph's prebuilt agent factory.
- Added a thorough explanation and a hand-rolled StateGraph equivalent that demonstrates what the factory constructs, plus a mermaid topology diagram.
- Documented rationale for choosing the factory and when the manual StateGraph would be preferable, and included references.

## Test plan

<!-- How to you verify your changes work? -->

- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes
- [ ] Manually test the newly added flow
- [ ] Edge cases covered (List in PR description)

## Notes for reviewer

<!-- Anything the reviewer should know or anything that should be known for later tracking purposes: trade-offs, follow-up issues, known limitations. -->
`create_agent` vs `create_react_agent`

This story uses from _langchain.agents import create_agent_ rather than the more commonly seen from _langgraph.prebuilt import create_react_agent_.

`create_react_agent` is deprecated in LangGraph 1.x. The new import is `create_agent from langchain.agents`: it is the same graph topology, just relocated as part of LangGraph's 1.x reorganisation. The return type is still a `CompiledStateGraph`.

ADR-004 documents the manual StateGraph equivalent so it's clear this isn't a black-box import. The prebuilt factory was chosen because it removes boilerplate that would otherwise need to be kept in sync with LangGraph internals as the library evolves.
