### PR TITLE
US5.6 - Add QueryService and make web search optional

### DIFF
--- a/app/services/agent.py
+++ b/app/services/agent.py
@@ -2,6 +2,7 @@ import uuid
 from typing import Any
 
 from langchain.agents import create_agent
+from langchain_core.tools import BaseTool
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.services.clarify_tool import clarify_tool
@@ -24,8 +25,11 @@ def build_agent(
     user_id: uuid.UUID,
     db: AsyncSession,
     max_iterations: int = _DEFAULT_MAX_ITERATIONS,
+    use_web_search: bool = True,
 ) -> Any:
-    tools = [make_retrieve_tool(user_id, db), web_search_tool, clarify_tool]
+    tools: list[BaseTool] = [make_retrieve_tool(user_id, db), clarify_tool]
+    if use_web_search:
+        tools.append(web_search_tool)
     agent = create_agent(
         model=get_chat_model(),
         tools=tools,

--- a/app/services/query_service.py
+++ b/app/services/query_service.py
@@ -1,0 +1,68 @@
+import uuid
+from typing import Any, TypedDict
+
+from langchain_core.messages import HumanMessage
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.query_history import QueryHistory
+from app.services.agent import build_agent
+from app.services.vector_store import SimilarityResult
+
+
+class QueryResult(TypedDict):
+    answer: str
+    sources: list[SimilarityResult]
+    used_web_search: bool
+
+
+async def run(
+    question: str,
+    use_web_search: bool,
+    user_id: uuid.UUID,
+    db: AsyncSession,
+) -> QueryResult:
+    agent = build_agent(user_id, db, use_web_search=use_web_search)
+    sources: list[SimilarityResult] = []
+    used_web_search_detected = False
+    final_state: dict[str, Any] | None = None
+
+    async for event in agent.astream_events(
+        {"messages": [HumanMessage(content=question)]},
+        version="v2",
+    ):
+        kind = event["event"]
+
+        if kind == "on_tool_end":
+            tool_name = event.get("name", "")
+            if tool_name == "retrieve":
+                output = event["data"].get("output")
+                if isinstance(output, list):
+                    sources.extend(output)
+            elif tool_name == "web_search_tool":
+                used_web_search_detected = True
+
+        elif kind == "on_chain_end":
+            output = event["data"].get("output")
+            if isinstance(output, dict) and "messages" in output:
+                final_state = output
+
+    answer = ""
+    if final_state:
+        last_msg = final_state["messages"][-1]
+        content = getattr(last_msg, "content", "")
+        answer = content if isinstance(content, str) else str(content)
+
+    record = QueryHistory(
+        user_id=user_id,
+        question=question,
+        answer=answer,
+        used_web_search=used_web_search_detected,
+    )
+    db.add(record)
+    await db.commit()
+
+    return QueryResult(
+        answer=answer,
+        sources=sources,
+        used_web_search=used_web_search_detected,
+    )

--- a/docs/adr/ADR-004-langgraph-over-langchain.md
+++ b/docs/adr/ADR-004-langgraph-over-langchain.md
@@ -129,7 +129,7 @@ agent = workflow.compile()
 flowchart TD
     START([START]) --> agent
 
-    agent["🤖 agent\nLLM decides next action\ncall_agent()"]
+    agent["agent\nLLM decides next action\ncall_agent()"]
 
     agent --> router{should_continue?}
 

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -1,17 +1,23 @@
 import uuid
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from app.services.agent import build_agent
 from app.services.clarify_tool import clarify_tool
 
 
-def _build(max_iterations: int = 10) -> object:
+def _build(max_iterations: int = 10, use_web_search: bool = True) -> Any:
     with (
         patch("app.services.agent.get_chat_model") as mock_llm,
         patch("app.services.agent.make_retrieve_tool", return_value=clarify_tool),
     ):
         mock_llm.return_value.bind_tools = MagicMock(return_value=mock_llm.return_value)
-        return build_agent(uuid.uuid4(), MagicMock(), max_iterations=max_iterations)
+        return build_agent(
+            uuid.uuid4(),
+            MagicMock(),
+            max_iterations=max_iterations,
+            use_web_search=use_web_search,
+        )
 
 
 def test_build_agent_returns_compiled_graph() -> None:
@@ -21,16 +27,23 @@ def test_build_agent_returns_compiled_graph() -> None:
 
 def test_build_agent_graph_has_tools_node() -> None:
     agent = _build()
-    assert "tools" in agent.nodes  # type: ignore[union-attr]
+    assert "tools" in agent.nodes
 
 
 def test_build_agent_includes_web_search_and_clarify_tools() -> None:
     agent = _build()
-    tool_names = set(agent.nodes["tools"].bound.tools_by_name.keys())  # type: ignore[union-attr]
+    tool_names = set(agent.nodes["tools"].bound.tools_by_name.keys())
     assert "web_search_tool" in tool_names
     assert "clarify_tool" in tool_names
 
 
 def test_build_agent_respects_max_iterations() -> None:
     agent = _build(max_iterations=5)
-    assert agent.config.get("recursion_limit") == 5  # type: ignore[union-attr]
+    assert agent.config.get("recursion_limit") == 5
+
+
+def test_build_agent_excludes_web_search_when_disabled() -> None:
+    agent = _build(use_web_search=False)
+    tool_names = set(agent.nodes["tools"].bound.tools_by_name.keys())
+    assert "web_search_tool" not in tool_names
+    assert "clarify_tool" in tool_names

--- a/tests/unit/test_query_service.py
+++ b/tests/unit/test_query_service.py
@@ -1,0 +1,106 @@
+import uuid
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from langchain_core.messages import AIMessage
+
+from app.services.query_service import run
+
+
+def _make_source() -> dict[str, Any]:
+    return {
+        "id": uuid.uuid4(),
+        "content": "RAG stands for Retrieval-Augmented Generation.",
+        "document_id": uuid.uuid4(),
+        "chunk_index": 0,
+        "similarity": 0.95,
+    }
+
+
+def _make_agent(events: list[dict[str, Any]]) -> MagicMock:
+    async def _astream_events(
+        *args: object, **kwargs: object
+    ) -> AsyncGenerator[dict[str, Any], None]:
+        for event in events:
+            yield event
+
+    agent = MagicMock()
+    agent.astream_events = _astream_events
+    return agent
+
+
+def _final_state_event(answer: str) -> dict[str, Any]:
+    return {
+        "event": "on_chain_end",
+        "name": "",
+        "data": {"output": {"messages": [AIMessage(content=answer)]}},
+    }
+
+
+def _retrieve_event(sources: list[Any]) -> dict[str, Any]:
+    return {"event": "on_tool_end", "name": "retrieve", "data": {"output": sources}}
+
+
+def _web_search_event() -> dict[str, Any]:
+    return {"event": "on_tool_end", "name": "web_search_tool", "data": {"output": []}}
+
+
+def _mock_db() -> MagicMock:
+    db = MagicMock()
+    db.commit = AsyncMock()
+    return db
+
+
+async def test_run_returns_answer() -> None:
+    agent = _make_agent([_final_state_event("The answer is 42.")])
+    db = _mock_db()
+    with patch("app.services.query_service.build_agent", return_value=agent):
+        result = await run("What is the answer?", False, uuid.uuid4(), db)
+    assert result["answer"] == "The answer is 42."
+
+
+async def test_run_extracts_sources_from_retrieve_event() -> None:
+    source = _make_source()
+    agent = _make_agent([_retrieve_event([source]), _final_state_event("Answer.")])
+    db = _mock_db()
+    with patch("app.services.query_service.build_agent", return_value=agent):
+        result = await run("What is RAG?", False, uuid.uuid4(), db)
+    assert result["sources"] == [source]
+
+
+async def test_run_accumulates_multiple_retrieve_calls() -> None:
+    s1, s2 = _make_source(), _make_source()
+    agent = _make_agent(
+        [_retrieve_event([s1]), _retrieve_event([s2]), _final_state_event("Answer.")]
+    )
+    db = _mock_db()
+    with patch("app.services.query_service.build_agent", return_value=agent):
+        result = await run("What is RAG?", False, uuid.uuid4(), db)
+    assert result["sources"] == [s1, s2]
+
+
+async def test_run_detects_web_search_used() -> None:
+    agent = _make_agent([_web_search_event(), _final_state_event("Found online.")])
+    db = _mock_db()
+    with patch("app.services.query_service.build_agent", return_value=agent):
+        result = await run("Latest news?", True, uuid.uuid4(), db)
+    assert result["used_web_search"] is True
+
+
+async def test_run_used_web_search_false_when_not_called() -> None:
+    source = _make_source()
+    agent = _make_agent([_retrieve_event([source]), _final_state_event("Answer.")])
+    db = _mock_db()
+    with patch("app.services.query_service.build_agent", return_value=agent):
+        result = await run("What is RAG?", False, uuid.uuid4(), db)
+    assert result["used_web_search"] is False
+
+
+async def test_run_persists_query_history() -> None:
+    agent = _make_agent([_final_state_event("The answer.")])
+    db = _mock_db()
+    with patch("app.services.query_service.build_agent", return_value=agent):
+        await run("question", False, uuid.uuid4(), db)
+    db.add.assert_called_once()
+    db.commit.assert_awaited_once()


### PR DESCRIPTION
## Summary

<!-- What does this PR do and why? Link the issue to PR and/or branch it fixes. -->
Add query service to handle LLm looping through tools and searching DB. Related to #41.

## Changes

<!-- Bullet list of the main changes. -->

- Introduces QueryService to handle query execution, event streaming, and source extraction from agent runs.
- Web search is now opt-in via `use_web_search` parameter in build_agent(), allowing callers to control tool availability.
- Adds comprehensive tests for both agent and query service, plus cleanup of type annotations in existing tests.

## Test plan

<!-- How to you verify your changes work? -->

- [x] `make lint` passes
- [x] `make typecheck` passes
- [x] `make test` passes
- [ ] Manually test the newly added flow
- [ ] Edge cases covered (List in PR description)

## Notes for reviewer

<!-- Anything the reviewer should know or anything that should be known for later tracking purposes: trade-offs, follow-up issues, known limitations. -->
None
